### PR TITLE
Allow clipping frame

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   collection:
     dependency: transitive
     description:
@@ -26,14 +26,21 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -52,7 +59,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/lib/flutter_web_frame.dart
+++ b/lib/flutter_web_frame.dart
@@ -1,6 +1,5 @@
 library flutter_web_frame;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'src/frame_content.dart';
@@ -21,12 +20,16 @@ class FlutterWebFrame extends StatefulWidget {
   /// Maximum size
   final Size maximumSize;
 
+  /// Clip behavior
+  final Clip clipBehavior;
+
   const FlutterWebFrame({
     Key? key,
     required this.builder,
     this.enabled = true,
     this.backgroundColor,
     required this.maximumSize,
+    this.clipBehavior = Clip.none,
   }) : super(key: key);
 
   /// A global builder that should be inserted into [WidgetApp]'s builder
@@ -118,6 +121,7 @@ class _FlutterWebFrameState extends State<FlutterWebFrame> {
       child: RepaintBoundary(
         child: FrameContent(
           size: widget.maximumSize,
+          clipBehavior: widget.clipBehavior,
           child: Builder(
             builder: widget.builder,
           ),

--- a/lib/src/frame_content.dart
+++ b/lib/src/frame_content.dart
@@ -4,11 +4,18 @@ class FrameContent extends StatelessWidget {
   /// Size frame
   final Size size;
 
+  /// Clip behavior
+  final Clip clipBehavior;
+
   /// Child widget
   final Widget child;
 
-  const FrameContent({Key? key, required this.size, required this.child})
-      : super(key: key);
+  const FrameContent({
+    Key? key,
+    required this.size,
+    required this.clipBehavior,
+    required this.child,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -34,13 +41,22 @@ class FrameContent extends StatelessWidget {
     final sizeWidth =
         currentSize.width > size.width ? size.width : currentSize.width;
 
-    return SizedBox(
+    final box = SizedBox(
       width: sizeWidth,
       height: MediaQuery.of(context).size.height,
       child: MediaQuery(
         data: FrameContent.mediaQuery(context, size),
         child: child,
       ),
+    );
+
+    if (clipBehavior == Clip.none) {
+      return box;
+    }
+
+    return ClipRect(
+      clipBehavior: clipBehavior,
+      child: box,
     );
   }
 }

--- a/lib/src/media_query_observer.dart
+++ b/lib/src/media_query_observer.dart
@@ -15,6 +15,9 @@ class MediaQueryObserver extends StatefulWidget {
 
 class _MediaQueryObserverState extends State<MediaQueryObserver>
     with WidgetsBindingObserver {
+
+  T? _ambiguate<T>(T? value) => value;
+
   @override
   void didChangeMetrics() {
     setState(() {});
@@ -23,20 +26,20 @@ class _MediaQueryObserverState extends State<MediaQueryObserver>
 
   @override
   void initState() {
-    WidgetsBinding.instance!.addObserver(this);
+    _ambiguate(WidgetsBinding.instance)!.addObserver(this);
     super.initState();
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance!.removeObserver(this);
+    _ambiguate(WidgetsBinding.instance)!.removeObserver(this);
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return MediaQuery(
-      data: MediaQueryData.fromWindow(WidgetsBinding.instance!.window),
+      data: MediaQueryData.fromWindow(_ambiguate(WidgetsBinding.instance)!.window),
       child: widget.child,
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -66,14 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -99,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -148,7 +155,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
When navigating between pages (where the routes transitions horizontally), the old page was visible outside the container. This PR allows setting clip behavior so you can clip the container. I set it to Clip.hardEdge.